### PR TITLE
Support openssl 1.1.1

### DIFF
--- a/.github/actions/nginx-module-toolbox/Dockerfile
+++ b/.github/actions/nginx-module-toolbox/Dockerfile
@@ -1,3 +1,7 @@
 FROM nicholaschiasson/nginx-module-toolbox:amazonlinux-2-1.18.0-1
 
+WORKDIR /src/openssl
+RUN curl -sL https://www.openssl.org/source/openssl-1.1.1g.tar.gz -o openssl.tar.gz
+RUN tar --strip-components=1 -xzf openssl.tar.gz
+
 WORKDIR /github/workspace

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -18,8 +18,6 @@ do
 	./configure \
 		--prefix=${BIN_DIR} \
 		--with-debug \
-		--with-http_ssl_module \
-		--with-openssl=/src/openssl \
 		--without-http_charset_module \
 		--without-http_userid_module \
 		--without-http_auth_basic_module \
@@ -36,7 +34,9 @@ do
 		--without-http_empty_gif_module \
 		--without-http_browser_module \
 		--without-http_upstream_ip_hash_module \
-		--add${TYPE}module=${GITHUB_WORKSPACE}
+		--add${TYPE}module=${GITHUB_WORKSPACE} \
+		# --with-http_ssl_module \
+		# --with-openssl=/src/openssl
 
 	make
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -18,6 +18,8 @@ do
 	./configure \
 		--prefix=${BIN_DIR} \
 		--with-debug \
+		--with-http_ssl_module \
+		--with-openssl=/src/openssl \
 		--without-http_charset_module \
 		--without-http_userid_module \
 		--without-http_auth_basic_module \

--- a/src/ngx_http_upstream_jdomain.c
+++ b/src/ngx_http_upstream_jdomain.c
@@ -597,12 +597,8 @@ ngx_http_upstream_set_jdomain_peer_session(ngx_peer_connection_t* pc,
 
 	rc = ngx_ssl_set_session(pc->connection, ssl_session);
 
-	ngx_log_debug2(NGX_LOG_DEBUG_HTTP,
-	               pc->log,
-	               0,
-	               "set session: %p:%d",
-	               ssl_session,
-	               ssl_session ? ssl_session->references : 0);
+	ngx_log_debug1(
+	  NGX_LOG_DEBUG_HTTP, pc->log, 0, "set session: %p", ssl_session);
 
 	return rc;
 }
@@ -622,12 +618,8 @@ ngx_http_upstream_save_jdomain_peer_session(ngx_peer_connection_t* pc,
 		return;
 	}
 
-	ngx_log_debug2(NGX_LOG_DEBUG_HTTP,
-	               pc->log,
-	               0,
-	               "save session: %p:%d",
-	               ssl_session,
-	               ssl_session->references);
+	ngx_log_debug1(
+	  NGX_LOG_DEBUG_HTTP, pc->log, 0, "save session: %p", ssl_session);
 
 	peer = &urpd->conf->peers[urpd->current];
 
@@ -635,12 +627,8 @@ ngx_http_upstream_save_jdomain_peer_session(ngx_peer_connection_t* pc,
 	peer->ssl_session = ssl_session;
 
 	if (old_ssl_session) {
-		ngx_log_debug2(NGX_LOG_DEBUG_HTTP,
-		               pc->log,
-		               0,
-		               "old session: %p:%d",
-		               old_ssl_session,
-		               old_ssl_session->references);
+		ngx_log_debug1(
+		  NGX_LOG_DEBUG_HTTP, pc->log, 0, "old session: %p", old_ssl_session);
 
 		ngx_ssl_free_session(old_ssl_session);
 	}


### PR DESCRIPTION
Fixes #46 

It looks like between openssl 1.0.X and 1.1.X, internal structures (once accessible with the absence of the `OPENSSL_NO_SSL_INTERN` define) have been moved to properly restrict direct access of their fields in favour of using accessor functions.

There is no accessor function for `struct ssl_session_st`'s `references` field, so by my judgement, we should not be attempting to access it directly. Therefore, I have removed its use from this project.

Frankly, I don't know how much value was added by debug logging that value in the first place, so I don't consider this a regressive change.