### PR TITLE
BUGFIX: Instance resolver state

### DIFF
--- a/src/ngx_http_upstream_jdomain_module.c
+++ b/src/ngx_http_upstream_jdomain_module.c
@@ -239,7 +239,9 @@ ngx_http_upstream_init_jdomain_peer(ngx_http_request_t *r, ngx_http_upstream_srv
 			  NGX_LOG_ALERT, r->connection->log, 0, "ngx_http_upstream_jdomain_module: ngx_resolve_name \"%V\" fail", &ctx->name);
 			continue;
 		}
-		instance[i].state.resolve.status = NGX_JDOMAIN_STATUS_WAIT;
+        if (ctx->state == NGX_AGAIN) {
+            instance[i].state.resolve.status = NGX_JDOMAIN_STATUS_WAIT;
+        }
 	}
 
 end:


### PR DESCRIPTION
Instance resolve status should only be set to **NGX_JDOMAIN_STATUS_WAIT** when resolver state is set to **NGX_AGAIN**.

Fixes #60, #61 and #74.

Caveat: Upstream DNS change is governed by `valid` argument of resolver directive.