### PR TITLE
avoid missing-field-initializers warn

### DIFF
--- a/src/ngx_http_upstream_jdomain_module.c
+++ b/src/ngx_http_upstream_jdomain_module.c
@@ -117,7 +117,7 @@ ngx_module_t ngx_http_upstream_jdomain_module = { NGX_MODULE_V1,
 	                                                NULL,                                  /* exit master */
 	                                                NGX_MODULE_V1_PADDING };
 
-static struct sockaddr_in NGX_JDOMAIN_INVALID_ADDR_SOCKADDR_IN = {};
+static struct sockaddr_in NGX_JDOMAIN_INVALID_ADDR_SOCKADDR_IN = {0};
 static const ngx_addr_t NGX_JDOMAIN_INVALID_ADDR = { (struct sockaddr *)(&NGX_JDOMAIN_INVALID_ADDR_SOCKADDR_IN),
 	                                                   sizeof(struct sockaddr_in),
 	                                                   ngx_string("NGX_UPSTREAM_JDOMAIN_BUFFER") };

--- a/src/ngx_http_upstream_jdomain_module.c
+++ b/src/ngx_http_upstream_jdomain_module.c
@@ -117,7 +117,7 @@ ngx_module_t ngx_http_upstream_jdomain_module = { NGX_MODULE_V1,
 	                                                NULL,                                  /* exit master */
 	                                                NGX_MODULE_V1_PADDING };
 
-static struct sockaddr_in NGX_JDOMAIN_INVALID_ADDR_SOCKADDR_IN = {0};
+static struct sockaddr_in NGX_JDOMAIN_INVALID_ADDR_SOCKADDR_IN = { 0 };
 static const ngx_addr_t NGX_JDOMAIN_INVALID_ADDR = { (struct sockaddr *)(&NGX_JDOMAIN_INVALID_ADDR_SOCKADDR_IN),
 	                                                   sizeof(struct sockaddr_in),
 	                                                   ngx_string("NGX_UPSTREAM_JDOMAIN_BUFFER") };


### PR DESCRIPTION
avoid missing-field-initializers warn

```
cc -c ../ngx_upstream_jdomain-1.5.0/src/ngx_http_upstream_jdomain_module.c:120:15: error: missing initializer for field ‘sin_family’ of ‘struct sockaddr_in’ [-Werror=missing-field-initializers]
 static struct sockaddr_in NGX_JDOMAIN_INVALID_ADDR_SOCKADDR_IN = {};
               ^
In file included from /usr/include/bits/socket.h:151:0,
                 from /usr/include/sys/socket.h:39,
                 from src/os/unix/ngx_linux_config.h:44,
                 from src/core/ngx_config.h:26,
                 from ../ngx_upstream_jdomain-1.5.0/src/ngx_http_upstream_jdomain_module.c:2:
/usr/include/netinet/in.h:242:5: note: ‘sin_family’ declared here
     __SOCKADDR_COMMON (sin_);
     ^
cc1: all warnings being treated as errors
make[1]: *** [objs/addon/src/ngx_http_upstream_jdomain_module.o] Error 1
make[1]: *** Waiting for unfinished jobs....
```